### PR TITLE
Refactor: Update source filtering and version numbers

### DIFF
--- a/MangaWorldSources/tachiyomibridge/build.gradle.kts
+++ b/MangaWorldSources/tachiyomibridge/build.gradle.kts
@@ -10,7 +10,7 @@ android {
     namespace = "com.programmersbox.tachiyomibridge"
 
     defaultConfig {
-        versionName = "1.0.6"
+        versionName = "1.0.7"
     }
 }
 

--- a/MangaWorldSources/tachiyomibridge/customtachiyomibridge/build.gradle.kts
+++ b/MangaWorldSources/tachiyomibridge/customtachiyomibridge/build.gradle.kts
@@ -10,7 +10,7 @@ android {
     namespace = "com.programmersbox.customtachiyomibridge"
 
     defaultConfig {
-        versionName = "1.0.2"
+        versionName = "1.0.3"
     }
 }
 

--- a/MangaWorldSources/tachiyomibridge/customtachiyomibridge/src/main/java/com/programmersbox/customtachiyomibridge/SourceLoader.kt
+++ b/MangaWorldSources/tachiyomibridge/customtachiyomibridge/src/main/java/com/programmersbox/customtachiyomibridge/SourceLoader.kt
@@ -45,7 +45,6 @@ class SourceLoader : KoinComponent {
             else -> emptyList()
         }
             .filterIsInstance<HttpSource>()
-            .filter { it.lang == "en" }
             .map { toSource(it, a, p) }
     }
 

--- a/MangaWorldSources/tachiyomibridge/src/main/java/com/programmersbox/tachiyomibridge/SourceLoader.kt
+++ b/MangaWorldSources/tachiyomibridge/src/main/java/com/programmersbox/tachiyomibridge/SourceLoader.kt
@@ -45,7 +45,6 @@ class SourceLoader : KoinComponent {
             else -> emptyList()
         }
             .filterIsInstance<HttpSource>()
-            .filter { it.lang == "en" }
             .map { toSource(it, a, p) }
     }
 


### PR DESCRIPTION
- Updated `SourceLoader` to remove the "en" language filter for `HttpSource` in both `tachiyomibridge` and `customtachiyomibridge`.
- Updated version number of `customtachiyomibridge` from 1.0.2 to 1.0.3.
- Updated version number of `tachiyomibridge` from 1.0.6 to 1.0.7.